### PR TITLE
Fix date error and release media player

### DIFF
--- a/app/src/main/java/com/android_examples/swipedetector_android_examplescom/MonitorThread.java
+++ b/app/src/main/java/com/android_examples/swipedetector_android_examplescom/MonitorThread.java
@@ -73,6 +73,7 @@ public class MonitorThread implements Runnable {
 
 	public void stopMeasuring() {
 		this.measuring = false;
+		mpRes.release();
 	}
 
 	public void fireActionFromActivity(GestureActions action) {
@@ -95,6 +96,10 @@ public class MonitorThread implements Runnable {
 				commandRequestTime = System.currentTimeMillis();
 
 				waitedGesture = actualAction;
+
+				if(mpRes != null){
+					mpRes.release();
+				}
 
 				// Say command
 				switch (actualAction) {
@@ -150,6 +155,10 @@ public class MonitorThread implements Runnable {
 							mpRes = MediaPlayer.create(mContext, R.raw.hiba);
 							mpRes.start();
 							finalResultOfTest = "NOK";
+						}
+
+						if(lastAnswerTime==0){
+							lastAnswerTime = System.currentTimeMillis();
 						}
 
 						// TODO: save out data


### PR DESCRIPTION
A héten alaposan belenéztem a programba és végigdebuggoltam az egészet. Ez a néhány módosítás a következő hibákat javítja:
- 18410-18502/com.android_examples.swipedetector_android_examplescom E/MediaPlayerNative: error (1, -19)
- 18410-18410/com.android_examples.swipedetector_android_examplescom E/MediaPlayer: Error (1,-19)
- default dátum, ha rossz input érkezett

Fennmaradó probléma, hogy 5-6 gesztust követően egyszerűen nem kér be semmit. Belemegy a switch-be de utána egyből az **else** ágba ugrik. Telepakoltam breakpointokkal az egészet, de szimplán ignorálja a **MainActivityClass onFling** metódusát. 

Először azt hittem, hogy a mediaplayer release-el okoztam, de anélkül is ugyanúgy fennáll a probléma. A méréseknél is csak elhalkul az egész és nem tudni, hogy a gesztus volt rossz vagy meghalt az egész.

```
waitForAction.postDelayed(new Runnable() {
					@Override
					public void run() {

						finalResultOfTest = "";

						// Todo evaluate the results and save
						if (actualGesture == waitedGesture) {
							mpRes = MediaPlayer.create(mContext, R.raw.ok);
							mpRes.start();
							finalResultOfTest = "Success";
						} else {
							mpRes = MediaPlayer.create(mContext, R.raw.hiba);
							mpRes.start();
							finalResultOfTest = "NOK";
						}
```

A magyarázat szerintem az lesz, hogy az actualGesture változó valahonnan kap egy értéket, anélkül, hogy azt bekérné a felhasználótól.

Ennek következtében pedig nem hívódik meg a fent említett függvény. Lehet a handlerben csúszik el valami, ahogy újabb szálat indít a háttérben. 

actualGesture pedig a korábbi értéket őrzi és nem kap újat a lenti metódusból, ami azért van, mert nem hívódik meg a MainActivityClass függvénye. 

```
	public void fireActionFromActivity(GestureActions action) {
		actualGesture = action;
		actionCounter++;
		lastAnswerTime = System.currentTimeMillis();
	}
```